### PR TITLE
fix: add `--no_launch_vim` flag and update test to use it

### DIFF
--- a/lib/jq/github.jq
+++ b/lib/jq/github.jq
@@ -9,6 +9,7 @@ def repo_title:
     "aspect-build/aspect-cli": "Aspect CLI",
     "aspect-build/bazel-lib": "Aspect Bazel Lib",
     "bazel-contrib/rules_bazel_integration_test": "Bazel Integration Test Rules",
+    "bazelbuild/bazel-gazelle": "Bazel Gazelle",
     "bazelbuild/rules_pkg": "Bazel Packaging Rules",
     "buildbuddy-io/rules_xcodeproj": "Xcode Project Generator",
     "cgrindel/bazel-starlib": "Bazel Starlib",
@@ -18,6 +19,7 @@ def repo_title:
     "cgrindel/rules_spm": "Swift Package Manager Rules for Bazel",
     "cgrindel/rules_swiftformat": "SwiftFormat Rules for Bazel",
     "cgrindel/spm_bazel": "SPM Bazel",
+    "cgrindel/swift_bazel": "Swift Bazel",
     "cgrindel/swift_toolbox": "Swift Toolbox"
   } as $repo_titles |
   [ ($repo_titles | getpath([$suffix])), "`\($suffix)`" ] |

--- a/tests/tools_tests/generate_weekly_snippets_test.sh
+++ b/tests/tools_tests/generate_weekly_snippets_test.sh
@@ -63,6 +63,7 @@ rm -rf "${snippets_dir}"
 mkdir -p "${snippets_dir}"
 
 "${generate_weekly_snippets_sh}" \
+  --no_launch_vim \
   --author cgrindel \
   --week_with_date "2022-01-05" \
   --snippets_dir "${snippets_dir}"
@@ -77,6 +78,7 @@ expected_snippets_file="${snippets_dir}/snippets_2022.md"
 # MARK - Test Updating An Existing Snippet File
 
 "${generate_weekly_snippets_sh}" \
+  --no_launch_vim \
   --author cgrindel \
   --week_with_date "2022-01-12" \
   --snippets_dir "${snippets_dir}"
@@ -92,6 +94,7 @@ expected_snippets_file="${snippets_dir}/snippets_2022.md"
 # MARK - Test Fail if Adding Snippets for Existing Week
 
 "${generate_weekly_snippets_sh}" \
+  --no_launch_vim \
   --author cgrindel \
   --week_with_date "2022-01-12" \
   --snippets_dir "${snippets_dir}" || echo "Expected failure occurred."

--- a/tools/generate_weekly_snippets.sh
+++ b/tools/generate_weekly_snippets.sh
@@ -180,7 +180,8 @@ if [[ -n "${snippets_dir:-}" ]]; then
   # Move new file
   mv "${tmp_file}" "${snippet_file_path}"
 
-  echo "Added snippets for the week ending ${week_ending_date} to \"${snippet_file_path// /\\ }\"."
+  echo "Added snippets for the week ending ${week_ending_date} to ${snippet_file_path// /\\ }."
+  vim "${snippet_file_path}"
 else
   # Output the markdown to stdout
   echo "${output}"

--- a/tools/generate_weekly_snippets.sh
+++ b/tools/generate_weekly_snippets.sh
@@ -62,9 +62,13 @@ Options:
                       snippets files (snippets_XXXX.md). If specified, the
                       script will identify the target snippets file, generate 
                       the snippets, and add them to front of the file.
+--no_launch_vim       Optional. Prevents vim from being launched with the 
+                      snippets file open.
 EOF
   )"
 }
+
+launch_vim="true"
 
 args=()
 while (("$#")); do
@@ -84,6 +88,10 @@ while (("$#")); do
     "--snippets_dir")
       snippets_dir="${2}"
       shift 2
+      ;;
+    "--no_launch_vim")
+      launch_vim="false"
+      shift 1
       ;;
     *)
       args+=("${1}")
@@ -181,7 +189,9 @@ if [[ -n "${snippets_dir:-}" ]]; then
   mv "${tmp_file}" "${snippet_file_path}"
 
   echo "Added snippets for the week ending ${week_ending_date} to ${snippet_file_path// /\\ }."
-  vim "${snippet_file_path}"
+  if [[ "${launch_vim}" == "true" ]]; then
+    vim "${snippet_file_path}"
+  fi
 else
   # Output the markdown to stdout
   echo "${output}"


### PR DESCRIPTION
Prevents the test from failing due to vim not being available.