### PR TITLE
feat: add issue activity to weekly snippets (and fix GNU/BSD date)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,12 @@ bazel run //:bzlformat_missing_pkgs_test    # CI check: every package has it
 bazel run //:update_all                     # run all updatesrc fixers
 ```
 
-The `//tests/tools_tests:generate_weekly_snippets_test` test calls
-GitHub's API through `gh`, so it needs `GH_TOKEN` or `GITHUB_TOKEN` in
-the environment (or a working `gh auth status`). Those vars are passed
-through via `env_inherit` in its `BUILD.bazel`.
+The `//tests/tools_tests:generate_weekly_snippets_test` test is
+hermetic: it injects a fake `gh` (`tests/tools_tests/fake_gh.sh`) via the
+generator's `GH_BIN` seam and serves canned JSON from
+`tests/tools_tests/fixtures/`, so it needs no network or GitHub auth. When
+you add or change a search query in `generate_weekly_snippets.sh`, update
+`fake_gh.sh`'s query dispatch and the matching fixture.
 
 ## Architecture
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -32,8 +32,8 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/MODULE.bazel": "01a1014e95e6816b68ecee2584ae929c7d6a1b72e4333ab1ff2d2c6c30babdf1",
-    "https://bcr.bazel.build/modules/aspect_rules_js/3.1.2/MODULE.bazel": "e3685502155d3cc65f3bf98e714f7435de67d7f8f355d63478a80197310311fc",
-    "https://bcr.bazel.build/modules/aspect_rules_js/3.1.2/source.json": "a32ab71831452b945f3f83a1b1feb9402007e600bce55ac76e15ef0c1e08b520",
+    "https://bcr.bazel.build/modules/aspect_rules_js/3.2.1/MODULE.bazel": "c1322ead2330fb8b8c84fc1b1cb4a053ab48c1c5da791b3732cb994b7c0dc2bb",
+    "https://bcr.bazel.build/modules/aspect_rules_js/3.2.1/source.json": "c57238951f8fbdc8d10ae79960e5190bf73c578a36b4d0a8b54f18d51837f963",
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
     "https://bcr.bazel.build/modules/aspect_rules_lint/2.6.0/MODULE.bazel": "2493658fb6414ee03601b29ee812bcb389627e81d2b8bb2d944d4e7bbff2c0a9",
     "https://bcr.bazel.build/modules/aspect_rules_lint/2.6.0/source.json": "b0050d5d2b34e1c74edd5c159e7ca85843b10208b884e401b089dc3484adc234",
@@ -308,7 +308,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "0XoIljUxggdpcUzxs00VnIbVvESNVqNnBVPRuMcsp4c=",
+        "usagesDigest": "eLSgwazK3iX331eIrAqM6FDUR905xX7LbWGwcDZatjA=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -318,7 +318,7 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_js": "3.1.2",
+                "aspect_rules_js": "3.2.1",
                 "aspect_rules_lint": "2.6.0",
                 "aspect_tools_telemetry": "0.3.3"
               }
@@ -489,7 +489,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "o6GN/E/kFiUiss+wcL/KOsa13iLuKpd1Q8UfC4paRvI=",
+        "usagesDigest": "HZQRujCure8cRH5NJWLK+HFTEmcE4hehbdVh6+BMsBU=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "nodejs_linux_amd64": {
@@ -818,7 +818,7 @@
     "@@yq.bzl+//yq:extensions.bzl%yq": {
       "general": {
         "bzlTransitiveDigest": "tDqk+ntWTdxNAWPDjRY1uITgHbti2jcXR5ZdinltBs0=",
-        "usagesDigest": "Pz33iK5QtkPFivaljfReN4KzpAqM2DgY4vwgyZSNoAM=",
+        "usagesDigest": "YnrbvFwYN54SzP+yCBLA/Q+5OzViAgIIzjczZiPM7O8=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "yq_darwin_amd64": {

--- a/lib/claude/summary_prompt.md
+++ b/lib/claude/summary_prompt.md
@@ -1,8 +1,10 @@
 You are drafting a weekly status summary for a developer based on their
 GitHub activity for the past week.
 
-The "Activity" Markdown block below lists pull requests the developer
-authored and reviewed, grouped by repository. Each PR has a title and URL.
+The "Activity" Markdown block below lists the developer's GitHub activity
+for the week — pull requests they authored and reviewed, plus issues they
+opened, closed, and commented on — grouped by repository. Each entry has a
+title and URL.
 
 Your job is to produce SUMMARY SECTIONS that describe the week's work in
 human-readable terms, grouped into two categories:

--- a/lib/claude/summary_prompt.md
+++ b/lib/claude/summary_prompt.md
@@ -9,8 +9,8 @@ title and URL.
 Your job is to produce SUMMARY SECTIONS that describe the week's work in
 human-readable terms, grouped into two categories:
 
-1. `## Glydways` — paid work at Glydways. Includes any PR in a repo under
-   the `glydways/*` GitHub organization (authored or reviewed).
+1. `## Glydways` — paid work at Glydways. Includes any activity (PR or
+   issue) in a repo under the `glydways/*` GitHub organization.
 2. `## Open Source` — personal and community work. Includes every other
    repository.
 
@@ -21,9 +21,13 @@ Format requirements:
   open-source activity.
 - Skip a category entirely (don't emit the heading) if it has no activity.
 - Under each heading, write 2-5 succinct bullets describing outcomes
-  ("Migrated X to Y", "Reviewed N dependency-update PRs from Renovate").
-  Group related PRs into a single bullet rather than enumerating each.
-- Bullets should focus on outcomes and themes, not PR titles.
+  ("Migrated X to Y", "Reviewed N dependency-update PRs from Renovate",
+  "Triaged and closed several flaky-test issues"). Draw on all the
+  activity — PRs authored and reviewed, and issues opened, closed, and
+  commented on. Group related items into a single bullet rather than
+  enumerating each.
+- Bullets should focus on outcomes and themes, not individual PR or issue
+  titles.
 - Plain Markdown only. No code fences. No preamble ("Here's the summary").
   No trailing commentary.
 - End the output with a single trailing newline.

--- a/lib/date.sh
+++ b/lib/date.sh
@@ -7,26 +7,103 @@ std_date_format_output="+${std_date_format}"
 # Add input value after expanding these args
 std_date_format_input_args=(-f "${std_date_format}")
 
+# Detect which `date` implementation is on PATH. BSD `date` (the macOS
+# system binary) uses `-j`/`-v`; GNU `date` (Linux, or Homebrew's
+# coreutils gnubin shadowing the system binary on macOS) uses `-d` and
+# rejects the BSD flags. Only GNU `date` understands `--version`.
+date_bin="date"
+if "${date_bin}" --version >/dev/null 2>&1; then
+  date_flavor="gnu"
+else
+  date_flavor="bsd"
+fi
+
 do_date_cmd() {
-  # BSD date (i.e. MacOS)
-  # Don't set the date and output date in UTC
-  cmd=(date -ju)
-  [[ ${#} > 0 ]] && cmd+=( "${@}")
-  "${cmd[@]}"
+  if [[ ${date_flavor} == "bsd" ]]; then
+    # BSD date (i.e. macOS): don't set the date, operate in UTC, and
+    # pass the BSD-style flags straight through.
+    "${date_bin}" -ju "${@}"
+    return
+  fi
+  _do_date_cmd_gnu "${@}"
 }
 
-find_beginning_of_week(){
+# Translate the BSD-style argument vector used throughout this file into a
+# GNU `date` invocation. Supported BSD constructs:
+#   -f FORMAT INPUT  parse INPUT (GNU parses ISO dates natively, so the
+#                    FORMAT is skipped)
+#   -v-mon           adjust to Monday of the current week
+#   -v[+-]Nd         add/subtract N days
+#   +OUTPUT          output format
+_do_date_cmd_gnu() {
+  local input_value=""
+  local has_input=0
+  local output_format=""
+  local bow=0
+  local -a day_specs=()
+
+  while [[ ${#} -gt 0 ]]; do
+    case "${1}" in
+      -f)
+        # BSD form is `-f FORMAT INPUT`; GNU parses ISO dates
+        # natively, so skip the format and let INPUT arrive as a
+        # positional argument below.
+        shift
+        ;;
+      -v-mon)
+        bow=1
+        ;;
+      -v[+-]*d)
+        local off="${1#-v}"
+        off="${off%d}"
+        day_specs+=("${off} days")
+        ;;
+      +*)
+        output_format="${1}"
+        ;;
+      *)
+        input_value="${1}"
+        has_input=1
+        ;;
+    esac
+    shift
+  done
+
+  local base="now"
+  [[ ${has_input} -eq 1 ]] && base="${input_value}"
+
+  local spec="${base}"
+  [[ ${#day_specs[@]} -gt 0 ]] && spec="${spec} ${day_specs[*]}"
+
+  if [[ ${bow} -eq 1 ]]; then
+    # GNU date has no "Monday of this week", so compute it: resolve the
+    # date, read its ISO weekday (1=Mon..7=Sun), and step back to
+    # Monday.
+    local resolved dow
+    resolved="$("${date_bin}" -u -d "${spec}" "+%Y-%m-%d")"
+    dow="$("${date_bin}" -u -d "${resolved}" "+%u")"
+    spec="${resolved} -$((dow - 1)) days"
+  fi
+
+  if [[ -n ${output_format} ]]; then
+    "${date_bin}" -u -d "${spec}" "${output_format}"
+  else
+    "${date_bin}" -u -d "${spec}"
+  fi
+}
+
+find_beginning_of_week() {
   local date="${1:-}"
   # Beginning of this week. It will return today, if today is Monday.
-  cmd=( do_date_cmd -v-mon )
-  [[ -n "${date:-}" ]] && cmd+=( "${std_date_format_input_args[@]}" "${date}" )
-  cmd+=( "${std_date_format_output}" )
+  cmd=(do_date_cmd -v-mon)
+  [[ -n ${date:-} ]] && cmd+=("${std_date_format_input_args[@]}" "${date}")
+  cmd+=("${std_date_format_output}")
   "${cmd[@]}"
 }
 
 find_beginning_of_previous_week() {
   local date="${1:-}"
-  local beginning_of_week="$( find_beginning_of_week "${date:-}" )"
+  local beginning_of_week="$(find_beginning_of_week "${date:-}")"
   days_before 7 "${beginning_of_week}"
 }
 
@@ -34,13 +111,13 @@ days_math() {
   # E.g. -1, +2
   local days=${1}
   local from_date="${2:-}"
-  cmd=( do_date_cmd )
+  cmd=(do_date_cmd)
   # Only attempt the math if the days value is greater than 0.
-  [[ ${days} != 0 ]] && cmd+=( "-v${days}d" )
+  [[ ${days} != 0 ]] && cmd+=("-v${days}d")
   # Input a specific date
-  [[ -n "${from_date}" ]] && cmd+=( "${std_date_format_input_args[@]}" "${from_date}" )
+  [[ -n ${from_date} ]] && cmd+=("${std_date_format_input_args[@]}" "${from_date}")
   # Print out the date as YYYY-MM-DD
-  cmd+=( "${std_date_format_output}" )
+  cmd+=("${std_date_format_output}")
   # Execute the command
   "${cmd[@]}"
 }
@@ -59,11 +136,11 @@ days_after() {
 
 get_year_from_date() {
   local date="${1}"
-  cmd=( do_date_cmd )
+  cmd=(do_date_cmd)
   # Input a specific date
-  cmd+=( "${std_date_format_input_args[@]}" "${date}" )
+  cmd+=("${std_date_format_input_args[@]}" "${date}")
   # Output just the year
-  cmd+=( "+%Y" )
+  cmd+=("+%Y")
   # Execute the command
   "${cmd[@]}"
 }

--- a/lib/jq/github.jq
+++ b/lib/jq/github.jq
@@ -64,7 +64,7 @@ def closed_repo_prs_to_md:
 
 def closed_pr_search_response_to_md:
   [ .items | group_by(.repository_url) | .[] | closed_repo_prs_to_md ] |
-  [ "### Authored" ] + . |
+  [ "### PRs Authored" ] + . |
   join("\n")
   ;
 
@@ -85,7 +85,7 @@ def reviewed_repo_prs_to_md:
 
 def reviewed_pr_search_response_to_md:
   [ .items | group_by(.repository_url) | .[] | reviewed_repo_prs_to_md ] |
-  [ "### Reviewed" ] + . |
+  [ "### PRs Reviewed" ] + . |
   join("\n")
   ;
 

--- a/lib/jq/github.jq
+++ b/lib/jq/github.jq
@@ -88,3 +88,39 @@ def reviewed_pr_search_response_to_md:
   [ "### Reviewed" ] + . |
   join("\n")
   ;
+
+# Issues
+#
+# Issues returned by the search/issues endpoint share the same shape as PRs
+# (title, html_url, repository_url), so the rendering mirrors the PR helpers.
+
+def issue_to_md:
+  "  - [\(.title)](\(.html_url))"
+  ;
+
+# Expects an array of issues that are already grouped by repository_url
+def repo_issues_to_md:
+  "- **\(.[0].repository_url | repo_title)**" as $repo |
+  map(. | issue_to_md) as $issue_mds |
+  [ $repo ] + $issue_mds |
+  join("\n")
+  ;
+
+# Renders a search response under the given Markdown heading.
+def issue_search_response_to_md($heading):
+  [ .items | group_by(.repository_url) | .[] | repo_issues_to_md ] |
+  [ $heading ] + . |
+  join("\n")
+  ;
+
+def opened_issue_search_response_to_md:
+  issue_search_response_to_md("### Issues Opened")
+  ;
+
+def closed_issue_search_response_to_md:
+  issue_search_response_to_md("### Issues Closed")
+  ;
+
+def commented_issue_search_response_to_md:
+  issue_search_response_to_md("### Issues Commented")
+  ;

--- a/tests/lib_tests/jq_tests/github_tests.txt
+++ b/tests/lib_tests/jq_tests/github_tests.txt
@@ -79,7 +79,39 @@ import "github" as github; github::closed_repo_prs_to_md
 # Basic
 import "github" as github; github::closed_pr_search_response_to_md
 {"items":[{"repository_url":"https://github.com/cgrindel/first_repo_url","title": "First PR","html_url":"https://first_pr_url"},{"repository_url":"https://github.com/cgrindel/second_repo_url","title": "Second PR","html_url":"https://second_pr_url"}]}
-"### Authored\n- **`cgrindel/first_repo_url`**\n  - [First PR](https://first_pr_url)\n- **`cgrindel/second_repo_url`**\n  - [Second PR](https://second_pr_url)"
+"### PRs Authored\n- **`cgrindel/first_repo_url`**\n  - [First PR](https://first_pr_url)\n- **`cgrindel/second_repo_url`**\n  - [Second PR](https://second_pr_url)"
+
+
+# MARK - reviewed_pr_search_response_to_md
+
+# Basic
+import "github" as github; github::reviewed_pr_search_response_to_md
+{"items":[{"repository_url":"https://github.com/cgrindel/repo_url","title": "A PR","html_url":"https://a_pr_url"}]}
+"### PRs Reviewed\n- **`cgrindel/repo_url`**\n  - [A PR](https://a_pr_url)"
+
+
+# MARK - opened_issue_search_response_to_md
+
+# Basic
+import "github" as github; github::opened_issue_search_response_to_md
+{"items":[{"repository_url":"https://github.com/cgrindel/repo_url","title": "An issue","html_url":"https://an_issue_url"}]}
+"### Issues Opened\n- **`cgrindel/repo_url`**\n  - [An issue](https://an_issue_url)"
+
+
+# MARK - closed_issue_search_response_to_md
+
+# Basic
+import "github" as github; github::closed_issue_search_response_to_md
+{"items":[{"repository_url":"https://github.com/cgrindel/repo_url","title": "An issue","html_url":"https://an_issue_url"}]}
+"### Issues Closed\n- **`cgrindel/repo_url`**\n  - [An issue](https://an_issue_url)"
+
+
+# MARK - commented_issue_search_response_to_md
+
+# Basic
+import "github" as github; github::commented_issue_search_response_to_md
+{"items":[{"repository_url":"https://github.com/cgrindel/repo_url","title": "An issue","html_url":"https://an_issue_url"}]}
+"### Issues Commented\n- **`cgrindel/repo_url`**\n  - [An issue](https://an_issue_url)"
 
 
 # MARK - repo_title

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -7,9 +7,10 @@ sh_test(
     name = "generate_weekly_snippets_test",
     srcs = ["generate_weekly_snippets_test.sh"],
     data = [
+        "fake_gh.sh",
         "//tools:generate_weekly_snippets",
         "@jq_toolchains//:resolved_toolchain",
-    ],
+    ] + glob(["fixtures/*.json"]),
     # The script invokes the source .sh directly via rlocation, so it does
     # not inherit env vars from the sh_binary target. We replay the same
     # env wiring here so the script's CLAUDE_BIN / PRETTIER_BIN_RUNFILE
@@ -20,10 +21,8 @@ sh_test(
         "PRETTIER_BIN_RUNFILE": "cgrindel_github_snippets/prettier_/prettier",
     },
     env_inherit = [
-        # The HOME, GH_TOKEN, and GITHUB_TOKEN environment variables help the gh utility find
-        # its auth info.
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
+        # HOME helps the vendored prettier/node toolchain locate its
+        # caches. The test stubs gh via GH_BIN, so no GitHub auth is needed.
         "HOME",
     ],
     toolchains = [

--- a/tests/tools_tests/fake_gh.sh
+++ b/tests/tools_tests/fake_gh.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Minimal stand-in for `gh`, used by generate_weekly_snippets_test to keep
+# the suite hermetic (no network, no auth, no rate limits). It implements
+# only the call the generator makes:
+#
+#   gh api -X GET search/issues -f q=<QUERY>
+#
+# and returns a canned fixture selected by the qualifiers in <QUERY>.
+
+set -o errexit -o nounset -o pipefail
+
+# Fixtures are co-located with this script. The test exports
+# FAKE_GH_FIXTURES_DIR (resolved via runfiles) so this works regardless of
+# the runfiles layout; fall back to a path relative to this script.
+fixtures_dir="${FAKE_GH_FIXTURES_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" && pwd)"}"
+
+# Extract the search query (the argument beginning with "q=").
+query=""
+for arg in "$@"; do
+  case "${arg}" in
+    q=*) query="${arg#q=}" ;;
+  esac
+done
+
+emit() {
+  cat "${fixtures_dir}/${1}"
+}
+
+# Match on the distinctive qualifier for each search the generator issues.
+case "${query}" in
+  *"type:pr"*"reviewed-by:"*) emit reviewed_prs.json ;;
+  *"type:pr"*"state:closed"*) emit closed_prs.json ;;
+  *"type:issue"*"commenter:"*) emit commented_issues.json ;;
+  *"type:issue"*"assignee:"*) emit closed_issues.json ;;
+  *"type:issue"*"created:"*) emit opened_issues.json ;;
+  *)
+    echo >&2 "fake_gh: unrecognized query: ${query}"
+    exit 1
+    ;;
+esac

--- a/tests/tools_tests/fixtures/closed_issues.json
+++ b/tests/tools_tests/fixtures/closed_issues.json
@@ -1,0 +1,9 @@
+{
+  "items": [
+    {
+      "title": "Fix the flaky date test",
+      "html_url": "https://github.com/cgrindel/example/issues/202",
+      "repository_url": "https://api.github.com/repos/cgrindel/example"
+    }
+  ]
+}

--- a/tests/tools_tests/fixtures/closed_prs.json
+++ b/tests/tools_tests/fixtures/closed_prs.json
@@ -1,0 +1,9 @@
+{
+  "items": [
+    {
+      "title": "Add the foo widget",
+      "html_url": "https://github.com/cgrindel/example/pull/101",
+      "repository_url": "https://api.github.com/repos/cgrindel/example"
+    }
+  ]
+}

--- a/tests/tools_tests/fixtures/commented_issues.json
+++ b/tests/tools_tests/fixtures/commented_issues.json
@@ -1,0 +1,9 @@
+{
+  "items": [
+    {
+      "title": "Discuss the release plan",
+      "html_url": "https://github.com/cgrindel/example/issues/203",
+      "repository_url": "https://api.github.com/repos/cgrindel/example"
+    }
+  ]
+}

--- a/tests/tools_tests/fixtures/opened_issues.json
+++ b/tests/tools_tests/fixtures/opened_issues.json
@@ -1,0 +1,9 @@
+{
+  "items": [
+    {
+      "title": "Snippets should include issues",
+      "html_url": "https://github.com/cgrindel/example/issues/201",
+      "repository_url": "https://api.github.com/repos/cgrindel/example"
+    }
+  ]
+}

--- a/tests/tools_tests/fixtures/reviewed_prs.json
+++ b/tests/tools_tests/fixtures/reviewed_prs.json
@@ -1,0 +1,9 @@
+{
+  "items": [
+    {
+      "title": "Tidy the build files",
+      "html_url": "https://github.com/cgrindel/example/pull/102",
+      "repository_url": "https://api.github.com/repos/cgrindel/example"
+    }
+  ]
+}

--- a/tests/tools_tests/generate_weekly_snippets_test.sh
+++ b/tests/tools_tests/generate_weekly_snippets_test.sh
@@ -72,9 +72,9 @@ output="$(
 assert_match "# Week Ending 2022-01-09" "${output}"
 
 # Every activity section is rendered, with the content from its fixture.
-assert_match "### Authored" "${output}"
+assert_match "### PRs Authored" "${output}"
 assert_match "https://github.com/cgrindel/example/pull/101" "${output}"
-assert_match "### Reviewed" "${output}"
+assert_match "### PRs Reviewed" "${output}"
 assert_match "https://github.com/cgrindel/example/pull/102" "${output}"
 assert_match "### Issues Opened" "${output}"
 assert_match "https://github.com/cgrindel/example/issues/201" "${output}"
@@ -103,18 +103,18 @@ expected_snippets_file="${snippets_dir}/snippets_2022.md"
   || fail "Expected to find snippets in created snippet file. ${expected_snippets_file}"
 
 # Sanity-check that prettier ran: it normalizes by inserting a blank line
-# between '### Authored' and the first repo bullet (the generator emits
+# between '### PRs Authored' and the first repo bullet (the generator emits
 # them with no blank line). This catches breakage in the prettier
 # toolchain wiring (e.g. after a Renovate bump of rules_js / rules_lint /
 # prettier itself) that would otherwise pass the other assertions.
 awk '
-  /^### Authored$/ {
+  /^### PRs Authored$/ {
     getline next_line
     if (next_line == "") { found = 1 }
   }
   END { exit !found }
 ' "${expected_snippets_file}" \
-  || fail "Expected prettier to insert a blank line after '### Authored' in ${expected_snippets_file}"
+  || fail "Expected prettier to insert a blank line after '### PRs Authored' in ${expected_snippets_file}"
 
 # MARK - Test Updating An Existing Snippet File
 
@@ -167,13 +167,13 @@ raw_snippets_file="${raw_snippets_dir}/snippets_2022.md"
   || fail "Expected raw snippets file to be created. ${raw_snippets_file}"
 
 # Inverse of the assertion above: with --no_format, prettier is skipped,
-# so the line right after '### Authored' should be the first repo bullet
+# so the line right after '### PRs Authored' should be the first repo bullet
 # (no blank line in between).
 awk '
-  /^### Authored$/ {
+  /^### PRs Authored$/ {
     getline next_line
     if (next_line == "") { found_blank = 1 }
   }
   END { exit found_blank }
 ' "${raw_snippets_file}" \
-  || fail "Expected NO blank line after '### Authored' under --no_format in ${raw_snippets_file}"
+  || fail "Expected NO blank line after '### PRs Authored' under --no_format in ${raw_snippets_file}"

--- a/tests/tools_tests/generate_weekly_snippets_test.sh
+++ b/tests/tools_tests/generate_weekly_snippets_test.sh
@@ -28,16 +28,30 @@ generate_weekly_snippets_sh_location=cgrindel_github_snippets/tools/generate_wee
 generate_weekly_snippets_sh="$(rlocation "${generate_weekly_snippets_sh_location}")" \
   || (echo >&2 "Failed to locate ${generate_weekly_snippets_sh_location}" && exit 1)
 
-# MARK - Set Up Git Repo
+# MARK - Hermetic gh
 
-# Clone this repo so that we have an actual git repository for the test
-repo_dir="${PWD}/repo"
+# Inject a fake gh so the test never touches the network, GitHub auth, or
+# rate limits. The generator picks it up via the GH_BIN seam, and the fake
+# returns canned fixtures keyed off the search qualifiers.
+fake_gh_location=cgrindel_github_snippets/tests/tools_tests/fake_gh.sh
+fake_gh="$(rlocation "${fake_gh_location}")" \
+  || (echo >&2 "Failed to locate ${fake_gh_location}" && exit 1)
+export GH_BIN="${fake_gh}"
+
+# Resolve the fixtures directory through runfiles and hand it to the fake so
+# it works regardless of the runfiles layout.
+a_fixture_location=cgrindel_github_snippets/tests/tools_tests/fixtures/closed_prs.json
+a_fixture="$(rlocation "${a_fixture_location}")" \
+  || (echo >&2 "Failed to locate ${a_fixture_location}" && exit 1)
+export FAKE_GH_FIXTURES_DIR="$(dirname "${a_fixture}")"
+
+# MARK - Fake Workspace
+
+# The generator cd's into BUILD_WORKSPACE_DIRECTORY and writes snippet files
+# there. It performs no git operations, so a plain directory suffices.
+repo_dir="${PWD}/workspace"
 rm -rf "${repo_dir}"
-repo_url="https://github.com/cgrindel/github_snippets"
-git clone "${repo_url}" "${repo_dir}" 2>/dev/null
-
-# Any utilities under test need to know where the workspace directory is. In
-# this case, we are faking it out by setting it to our cloned repo directory.
+mkdir -p "${repo_dir}"
 export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
 
 # MARK - Test Using Defaults
@@ -56,8 +70,18 @@ output="$(
     --week_with_date "2022-01-05"
 )"
 assert_match "# Week Ending 2022-01-09" "${output}"
-assert_match "https://github.com/cgrindel/bazel-doc/pull/15" "${output}"
-assert_match "https://github.com/cgrindel/gha_select_value/pull/2" "${output}"
+
+# Every activity section is rendered, with the content from its fixture.
+assert_match "### Authored" "${output}"
+assert_match "https://github.com/cgrindel/example/pull/101" "${output}"
+assert_match "### Reviewed" "${output}"
+assert_match "https://github.com/cgrindel/example/pull/102" "${output}"
+assert_match "### Issues Opened" "${output}"
+assert_match "https://github.com/cgrindel/example/issues/201" "${output}"
+assert_match "### Issues Closed" "${output}"
+assert_match "https://github.com/cgrindel/example/issues/202" "${output}"
+assert_match "### Issues Commented" "${output}"
+assert_match "https://github.com/cgrindel/example/issues/203" "${output}"
 
 # MARK - Test Creating a New Snippet File
 

--- a/tools/generate_weekly_snippets.sh
+++ b/tools/generate_weekly_snippets.sh
@@ -60,15 +60,47 @@ summary_prompt_path="$(rlocation "${summary_prompt_location}")" \
 prettier_bin="$(rlocation "${PRETTIER_BIN_RUNFILE}")" \
   || (echo >&2 "Failed to locate ${PRETTIER_BIN_RUNFILE}" && exit 1)
 
-gh_location=multitool/tools/gh/gh
-gh="$(rlocation "${gh_location}")" \
-  || (echo >&2 "Failed to locate ${gh_location}" && exit 1)
+# Resolve the gh binary. Tests inject a stand-in via GH_BIN to stay
+# hermetic; normal runs locate the vendored multitool gh through runfiles.
+if [[ -n ${GH_BIN:-} ]]; then
+  gh="${GH_BIN}"
+else
+  gh_location=multitool/tools/gh/gh
+  gh="$(rlocation "${gh_location}")" \
+    || (echo >&2 "Failed to locate ${gh_location}" && exit 1)
+fi
 
 # MARK - Functions
 
-search_prs() {
+# Query GitHub's search/issues endpoint, which covers both pull requests
+# and issues. The caller supplies the qualifiers (e.g. type:pr, author:...).
+#
+# The Search API enforces a low rate limit (~30 requests/minute) and a single
+# snippet run issues several searches, so retry with exponential backoff when
+# GitHub throttles us (HTTP 403/429 "rate limit"). Other failures surface
+# immediately.
+search_issues() {
   query_args_str="${*}"
-  "${gh}" api -X GET search/issues -f q="${query_args_str}"
+  local attempt=1
+  local max_attempts=5
+  local delay=15
+  local out
+  while true; do
+    if out="$("${gh}" api -X GET search/issues -f q="${query_args_str}" 2>&1)"; then
+      printf '%s' "${out}"
+      return 0
+    fi
+    if [[ ${attempt} -ge ${max_attempts} ]] \
+      || ! grep -qi "rate limit" <<<"${out}"; then
+      echo >&2 "${out}"
+      return 1
+    fi
+    echo >&2 "GitHub rate limit hit; retrying in ${delay}s" \
+      "(attempt ${attempt}/${max_attempts})."
+    sleep "${delay}"
+    delay=$((delay * 2))
+    attempt=$((attempt + 1))
+  done
 }
 
 # MARK - Process Args
@@ -170,7 +202,7 @@ end_date="$(days_after 7 "${begin_date}")"
 
 # Retrieve the closed PRs
 closed_prs_result="$(
-  search_prs "type:pr" "state:closed" "author:${author}" \
+  search_issues "type:pr" "state:closed" "author:${author}" \
     "closed:${begin_date}..${end_date}"
 )"
 closed_prs_md="$(
@@ -180,13 +212,50 @@ closed_prs_md="$(
 )"
 
 reviewed_prs_result="$(
-  search_prs "type:pr" "-author:${author}" "reviewed-by:${author}" \
+  search_issues "type:pr" "-author:${author}" "reviewed-by:${author}" \
     "updated:${begin_date}..${end_date}"
 )"
 reviewed_prs_md="$(
   echo "${reviewed_prs_result}" \
     | "${jq_bin}" -r -L "${jq_lib_dir}" \
       'import "github" as github; github::reviewed_pr_search_response_to_md '
+)"
+
+# Retrieve issues the author opened this week.
+opened_issues_result="$(
+  search_issues "type:issue" "author:${author}" \
+    "created:${begin_date}..${end_date}"
+)"
+opened_issues_md="$(
+  echo "${opened_issues_result}" \
+    | "${jq_bin}" -r -L "${jq_lib_dir}" \
+      'import "github" as github; github::opened_issue_search_response_to_md '
+)"
+
+# Retrieve issues the author drove to closure this week. GitHub search has no
+# "closed-by" qualifier, so we approximate with issues assigned to the author
+# that were closed during the week.
+closed_issues_result="$(
+  search_issues "type:issue" "assignee:${author}" "state:closed" \
+    "closed:${begin_date}..${end_date}"
+)"
+closed_issues_md="$(
+  echo "${closed_issues_result}" \
+    | "${jq_bin}" -r -L "${jq_lib_dir}" \
+      'import "github" as github; github::closed_issue_search_response_to_md '
+)"
+
+# Retrieve issues the author commented on this week. There is no
+# "commented-on:<date>" qualifier, so we filter by last-updated like the
+# reviewed-PRs query.
+commented_issues_result="$(
+  search_issues "type:issue" "commenter:${author}" \
+    "updated:${begin_date}..${end_date}"
+)"
+commented_issues_md="$(
+  echo "${commented_issues_result}" \
+    | "${jq_bin}" -r -L "${jq_lib_dir}" \
+      'import "github" as github; github::commented_issue_search_response_to_md '
 )"
 
 # Assemble the activity Markdown that Claude will summarize (and that we'll
@@ -198,6 +267,12 @@ activity_md="$(
 ${closed_prs_md}
 
 ${reviewed_prs_md}
+
+${opened_issues_md}
+
+${closed_issues_md}
+
+${commented_issues_md}
 EOF
 )"
 


### PR DESCRIPTION
Two changes on this branch:

- Fixed the `date: invalid option -- 'j'` failure. `lib/date.sh` was hardcoded for BSD `date`, which breaks when GNU coreutils shadows the system `date` on PATH (and on Linux). It now detects the `date` flavor at load time and translates the BSD-style calls to GNU when needed — both paths verified.
- Added GitHub issue activity to the snippets: issues you opened, closed, and commented on, rendered alongside the authored/reviewed PR sections. GitHub search has no "closed-by" qualifier, so closed issues are approximated via `assignee` + `state:closed`.

Also reworked the generator test to be hermetic: it injects a fake `gh` through a new `GH_BIN` seam and serves canned fixtures, so it no longer hits the live GitHub API (the extra issue searches pushed it past GitHub's ~30/min search rate limit). Added retry/backoff to `search_issues` for real weekly runs too.

Full suite passes (24/24), buildifier fmt+lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)